### PR TITLE
Use ChaCha20 instead of AESGCM

### DIFF
--- a/creepy/protocol/common.py
+++ b/creepy/protocol/common.py
@@ -1,11 +1,10 @@
 import secrets
-
 from cryptography.hazmat.primitives.ciphers import aead
 
 
-class AES256GCM:
+class ChaCha20Poly1305:
     KEY_BITS = 256
-    NONCE_BYTES = 16
+    NONCE_BYTES = 12
 
     @property
     def name(self):
@@ -13,7 +12,7 @@ class AES256GCM:
 
     def __init__(self, key):
         assert len(key) * 8 == self.KEY_BITS
-        self._cipher = aead.AESGCM(key)
+        self._cipher = aead.ChaCha20Poly1305(key)
         self.key = key
 
     def encrypt(self, message):
@@ -27,7 +26,7 @@ class AES256GCM:
 
 def make_cipher(algo_name, key=None):
     _symmetric_algos = {
-        'AES256GCM': AES256GCM
+        'ChaCha20Poly1305': ChaCha20Poly1305,
     }
     algo = _symmetric_algos.get(algo_name)
     if algo is None:

--- a/creepy/protocol/handshake.py
+++ b/creepy/protocol/handshake.py
@@ -28,8 +28,8 @@ class HandshakeProtocol:
     HASH_ALGORITHM = cryptography.hazmat.primitives.hashes.SHA512()
     _VERSION = 0
     _HI_ALICE_FORMAT = struct.Struct(f'!IQ{HASH_ALGORITHM.digest_size}s')
-    _HI_BOB_FORMAT = struct.Struct('!4s16p32s')  # TODO(Roman Rizvanov): Fix hardcoded sizes.
-    TRANSPORT_CIPHER_NAME = 'AES256GCM'
+    _HI_BOB_FORMAT = struct.Struct('!4s12p32s')  # TODO(Roman Rizvanov): Fix hardcoded sizes.
+    TRANSPORT_CIPHER_NAME = 'ChaCha20Poly1305'
 
     def __init__(self, authorized_keys_path=None):
         self.salt = secrets.token_bytes(self.SALT_SIZE)

--- a/creepy/subprocess/common.py
+++ b/creepy/subprocess/common.py
@@ -65,7 +65,7 @@ def secure_alice(send, recv):
 def secure_bob(send, recv):
     backend = backends.default_backend()
     onetime_public_key = serialization.load_ssh_public_key(recv(), backend=backend)
-    cipher_name = 'AES256GCM'
+    cipher_name = 'ChaCha20Poly1305'
     send(cipher_name.encode())
     cipher = make_cipher(cipher_name)
     send(onetime_public_key.encrypt(cipher.key, _OAEP_PADDING))


### PR DESCRIPTION
Tests are passing except #61. Output:

```pytest
❯ pytest --tb=line .
===================================== test session starts ======================================
platform linux -- Python 3.10.4, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/veotani/itesoro/creepy
plugins: repeat-0.9.1, cov-4.0.0, anyio-3.6.2, asyncio-0.21.0, hypothesis-6.70.0, timeout-2.1.0
asyncio: mode=strict
collected 9 items                                                                              

creepy/protocol/tests/test_asymmetric.py .                                               [ 11%]
creepy/tests/test_serialization.py ..                                                    [ 33%]
creepy/types/tests/test_secure_string.py ...                                             [ 66%]
creepy/utils/tests/test_processify.py .FF                                                [100%]

=========================================== FAILURES ===========================================
/home/veotani/miniconda3/lib/python3.10/multiprocessing/connection.py:388: EOFError
/home/veotani/miniconda3/lib/python3.10/multiprocessing/connection.py:388: EOFError
======================================= warnings summary =======================================
../../miniconda3/lib/python3.10/site-packages/starlette/routing.py:594
  /home/veotani/miniconda3/lib/python3.10/site-packages/starlette/routing.py:594: DeprecationWarning: The on_startup and on_shutdown parameters are deprecated, and they will be removed on version 1.0. Use the lifespan parameter instead. See more about it on https://www.starlette.io/lifespan/.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================== short test summary info ====================================
FAILED creepy/utils/tests/test_processify.py::test_processify_child_crash - EOFError
FAILED creepy/utils/tests/test_processify.py::test_processify_parent_crash - EOFError
============================ 2 failed, 7 passed, 1 warning in 6.44s ============================
```