### PR TITLE
Private numbers fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,12 @@ max-line-length = 120
 max-complexity = 10
 ignore = E731,E228,E225,E226,E704
 
+[isort]
+line_length = 120
+no_lines_before = LOCALFOLDER
+lines_after_imports = 2
+length_sort_straight = True
+
 [metadata]
 name = creepy
 license_files = LICENSE.txt

--- a/src/creepy/serialization.py
+++ b/src/creepy/serialization.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
-from typing import Optional
 from contextlib import ExitStack
+from typing import Optional
 
 from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import serialization
@@ -64,7 +64,7 @@ def load_private_key(path=None, passphrase: Optional[SecureString] = None, ssh_d
     path = _find_key(path, ssh_dir=ssh_dir)
     if path is None:
         raise RuntimeError('Failed to find private key file')
-    process = Pypen('_detail/private_key', hash='89760b42e975c74dcd7b99b42b1ed000fca471dd824cc94e817cf7e47cfec332')
+    process = Pypen('_detail/private_key', hash='e2904bc7b89e6e8d24c20d389f995e02fa4bf245bfa6df58c03e94da07562c6d')
     process.request('load', str(path), passphrase)
     return ProcessifiedPrivateKey(process)
 


### PR DESCRIPTION
I tried to make code have functions from the issue (`get_public_numbers` and `get_d`) but I'd better do `serialize` that returns `(n, e, d)`. Is there a reason why we shouldn't do that?

Closes #74.