### PR TITLE
Fix `Pypen.__init__`

### DIFF
--- a/src/creepy/subprocess/pypen.py
+++ b/src/creepy/subprocess/pypen.py
@@ -50,7 +50,7 @@ class Pypen:
         except IndexError:
             raise ValueError('`args` is invalid') from None
         try:
-            caller_dir = os.path.dirname(inspect.stack()[1].filename)
+            caller_dir = os.path.dirname(inspect.stack(0)[1].filename)
             filename = os.path.join(caller_dir, filename)
         except Exception:
             pass


### PR DESCRIPTION
>The optional context argument supported by most of these functions specifies the number of lines of context to return, which are centered around the current line.

We don't need any lines here, just the filename. It also prevents reading the source code which speeds up creepy import.