### PR TITLE
Fix processify on Python 3.14

### DIFF
--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -21,15 +21,18 @@ def processify(fn):
     """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        in_connection, out_connection = _process_context.Pipe(duplex=False)
+        process_context = _get_process_context()
+        in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
             # Delay SIGINT until `start()` stores the child PID, so cleanup can always reach the worker.
             previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             try:
-                job_process = _process_context.Process(
+                job_process = process_context.Process(
                     target=_job,
-                    args=(os.getpid(), out_connection, fn, args, kwargs, previous_signal_mask),
+                    args=(
+                        os.getpid(), in_connection, out_connection, fn, args, kwargs, previous_signal_mask,
+                    ),
                 )
                 # This scope is process-wide on regular CPython, so match only the expected `fork` warning.
                 with warnings.catch_warnings():
@@ -90,7 +93,12 @@ def _kill_join(process: multiprocessing.Process, *, wait=False):
         Thread(target=process.join, daemon=True).start()
 
 
-def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, kwargs: dict, signal_mask):
+def _job(
+        ppid: int, in_connection: PipeConnection, out_connection: PipeConnection,
+        fn: Callable, args: tuple, kwargs: dict, signal_mask,
+):
+    # `fork` inherits both pipe ends, but the child only writes the response.
+    in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
     Thread(target=_suicide_when_orphan, args=(ppid,), daemon=True).start()
@@ -104,5 +112,9 @@ def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, k
         out_connection.close()
 
 
-# Local and decorated functions cannot be serialized for `spawn` or `forkserver` by the standard pickler.
-_process_context = multiprocessing.get_context('fork')
+def _get_process_context():
+    # Local and decorated functions cannot be serialized for `spawn` or `forkserver` by the standard pickler.
+    try:
+        return multiprocessing.get_context('fork')
+    except ValueError:
+        raise RuntimeError("processify requires platform support for the 'fork' multiprocessing start method") from None

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -24,9 +24,8 @@ def processify(fn=None, *, context='fork'):
     ----
     It doesn't encrypt communications with a child process.
     The default `fork` context supports local and decorated functions independently of the application context.
-    With `spawn` and `forkserver`, `fn` must be a module-level function or a regular or static method. When stacking
-    decorators, `processify` must be outermost and inner decorators must use `functools.wraps`. Arguments, results, and
-    exceptions must be pickleable.
+    With `spawn` and `forkserver`, `fn` or its `processify` wrapper must be importable by module and qualified name.
+    Arguments, results, and exceptions must be pickleable.
     Results must not depend on the worker remaining alive after they are deserialized.
     Functions using `fork` must not use inherited mutable global state or synchronization primitives.
     In multithreaded processes, SIGINT protection during worker startup is best-effort because signal masks are
@@ -162,8 +161,8 @@ def _get_job_fn(process_context, fn, wrapper):
             pickle.dumps(wrapper)
         except (pickle.PickleError, AttributeError, TypeError):
             raise RuntimeError(
-                f'processify using {process_context.get_start_method()!r} requires a module-level function '
-                'or a regular or static method; apply processify outermost and use functools.wraps in inner decorators',
+                f'processify using {process_context.get_start_method()!r} requires `fn` or its wrapper '
+                'to be importable by module and qualified name',
             ) from None
         # The importable decorated name resolves to `wrapper`; the child bypasses this `processify` layer once.
         return wrapper, True

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -49,11 +49,14 @@ def processify(fn=None, *, context='fork'):
                         in_connection, out_connection, wrapper, args, kwargs, previous_signal_mask,
                     ),
                 )
-                # This scope is process-wide on regular CPython, so limit suppression to the `fork` backend.
                 with warnings.catch_warnings():
+                    # Python 3.12+ warns when the `fork` backend is used from a multithreaded process.
+                    # Suppress that expected warning only during worker startup.
                     warnings.filterwarnings(
                         'ignore',
                         category=DeprecationWarning,
+                        # Warning filters are process-wide on regular CPython, so restrict suppression to the `fork`
+                        # backend.
                         module=r'multiprocessing\.popen_fork',
                     )
                     job_process.start()

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -1,6 +1,7 @@
 import os
 import time
 import signal
+import warnings
 import functools
 import multiprocessing
 from multiprocessing.connection import Connection as PipeConnection
@@ -15,29 +16,41 @@ def processify(fn):
     Note
     ----
     It doesn't encrypt communications with a child process.
-    It uses `fork` to support local and decorated functions, so call it only from a single-threaded process.
+    It uses `fork` to support local and decorated functions, so `fn` must not use inherited global state.
     """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         in_connection, out_connection = _process_context.Pipe(duplex=False)
         job_process = _process_context.Process(target=_job, args=(os.getpid(), out_connection, fn, args, kwargs))
         try:
-            job_process.start()
-        except Exception:
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    'ignore',
+                    message=r'This process .* is multi-threaded, use of fork\(\) may lead to deadlocks in the child\.',
+                    category=DeprecationWarning,
+                    module=r'multiprocessing\.popen_fork',
+                )
+                job_process.start()
+            out_connection.close()
+        except BaseException:
             in_connection.close()
             out_connection.close()
+            if job_process.pid is not None:
+                _kill_join(job_process)
             raise
-        out_connection.close()
         try:
-            try:
-                response = in_connection.recv()
-            except EOFError:
-                response = None
+            response = in_connection.recv()
+        except EOFError:
+            job_process.kill()
+            job_process.join()
+            raise RuntimeError(f'Process running {fn} exited with code {job_process.exitcode}') from None
+        except BaseException:
+            _kill_join(job_process)
+            raise
+        else:
+            _kill_join(job_process)
         finally:
             in_connection.close()
-            job_process.join()
-        if response is None:
-            raise RuntimeError(f'Process running {fn} exited with code {job_process.exitcode}')
         result, exception = response
         if exception is not None:
             raise exception
@@ -53,16 +66,22 @@ def _suicide_when_orphan(ppid: int):
     os.kill(os.getpid(), signal.SIGKILL)  # suicide
 
 
+def _kill_join(process: multiprocessing.Process):
+    """Kill `process` and join it in background."""
+    process.kill()
+    Thread(target=process.join, daemon=True).start()
+
+
 def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, kwargs: dict):
     Thread(target=_suicide_when_orphan, args=(ppid,), daemon=True).start()
     try:
         result = (fn(*args, **kwargs), None)
     except Exception as e:
         result = (None, e)
-    out_connection.send(result)
+    try:
+        out_connection.send(result)
+    finally:
+        out_connection.close()
 
 
-try:
-    _process_context = multiprocessing.get_context('fork')
-except ValueError:
-    _process_context = multiprocessing.get_context()
+_process_context = multiprocessing.get_context('fork')

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -23,8 +23,7 @@ def processify(fn=None, *, context='fork'):
     ----
     It doesn't encrypt communications with a child process.
     The default `fork` context supports local and decorated functions independently of the application context.
-    With `spawn` and `forkserver`, use `processify` as a decorator; the decorated name must resolve to its wrapper
-    by module and qualified name.
+    With `spawn` and `forkserver`, decorated functions must be importable by module and qualified name.
     Arguments, results, and exceptions must be pickleable.
     Results must not depend on the worker remaining alive after they are deserialized.
     Functions using `fork` must not use inherited mutable global state or synchronization primitives.
@@ -35,9 +34,6 @@ def processify(fn=None, *, context='fork'):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         process_context = _get_process_context(context)
-        # A spawn-like child imports this wrapper, so the decorated name must resolve to it.
-        unwrap_fn = process_context.get_start_method() != 'fork'
-        job_fn = wrapper if unwrap_fn else fn
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
@@ -48,18 +44,13 @@ def processify(fn=None, *, context='fork'):
                 job_process = process_context.Process(
                     target=_job,
                     args=(
-                        in_connection, out_connection, job_fn, unwrap_fn,
-                        args, kwargs, previous_signal_mask,
+                        in_connection, out_connection, wrapper, args, kwargs, previous_signal_mask,
                     ),
                 )
-                # This scope is process-wide on regular CPython, so match only the expected `fork` warning.
+                # This scope is process-wide on regular CPython, so limit suppression to the `fork` backend.
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         'ignore',
-                        message=(
-                            r'This process .* is multi-threaded, use of fork\(\) may lead '
-                            r'to deadlocks in the child\.'
-                        ),
                         category=DeprecationWarning,
                         module=r'multiprocessing\.popen_fork',
                     )
@@ -117,17 +108,16 @@ def _kill_join(process: Optional[multiprocessing.Process], *, wait=False):
 
 
 def _job(
-        in_connection: PipeConnection, out_connection: PipeConnection, fn: Callable,
-        unwrap_fn: bool, args: tuple, kwargs: dict, signal_mask,
+        in_connection: PipeConnection, out_connection: PipeConnection, wrapper: Callable,
+        args: tuple, kwargs: dict, signal_mask,
 ):
     # `fork` inherits both pipe ends, but the child only writes the response.
     in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
     Thread(target=_suicide_when_orphan, daemon=True).start()
-    if unwrap_fn:
-        # `spawn` and `forkserver` can import the module-level wrapper; `__wrapped__` bypasses this decorator once.
-        fn = fn.__wrapped__
+    # `functools.wraps` stores the callable passed to `processify`, so only this decorator layer is bypassed.
+    fn = wrapper.__wrapped__
     try:
         result = (fn(*args, **kwargs), None)
     except Exception as e:

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -28,8 +28,6 @@ def processify(fn=None, *, context='fork'):
     Arguments, results, and exceptions must be pickleable.
     Results must not depend on the worker remaining alive after they are deserialized.
     Functions using `fork` must not use inherited mutable global state or synchronization primitives.
-    In multithreaded processes, SIGINT protection during worker startup is best-effort because signal masks are
-    thread-local.
     """
     if fn is None:
         return functools.partial(_processify, context=context)

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -1,12 +1,11 @@
 import os
-import pickle
 import signal
 import warnings
 import functools
 import multiprocessing
 from multiprocessing.connection import Connection as PipeConnection
 from threading import Thread
-from typing import Callable
+from typing import Callable, Optional
 
 
 def processify(fn=None, *, context='fork'):
@@ -24,21 +23,21 @@ def processify(fn=None, *, context='fork'):
     ----
     It doesn't encrypt communications with a child process.
     The default `fork` context supports local and decorated functions independently of the application context.
-    With `spawn` and `forkserver`, `fn` or its `processify` wrapper must be importable by module and qualified name.
+    With `spawn` and `forkserver`, use `processify` as a decorator; the decorated name must resolve to its wrapper
+    by module and qualified name.
     Arguments, results, and exceptions must be pickleable.
     Results must not depend on the worker remaining alive after they are deserialized.
     Functions using `fork` must not use inherited mutable global state or synchronization primitives.
     """
     if fn is None:
-        return functools.partial(_processify, context=context)
-    return _processify(fn, context=context)
+        return functools.partial(processify, context=context)
 
-
-def _processify(fn, *, context):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         process_context = _get_process_context(context)
-        job_fn, unwrap_fn = _get_job_fn(process_context, fn, wrapper)
+        # A spawn-like child imports this wrapper, so the decorated name must resolve to it.
+        unwrap_fn = process_context.get_start_method() != 'fork'
+        job_fn = wrapper if unwrap_fn else fn
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
@@ -71,8 +70,7 @@ def _processify(fn, *, context):
         except BaseException:
             in_connection.close()
             out_connection.close()
-            if job_process is not None and job_process.pid is not None:
-                _kill_join(job_process)
+            _kill_join(job_process)
             raise
         try:
             response = in_connection.recv()
@@ -105,8 +103,10 @@ def _suicide_when_orphan():
     os.kill(os.getpid(), signal.SIGKILL)  # suicide
 
 
-def _kill_join(process: multiprocessing.Process, *, wait=False):
-    """Kill `process` if it is running and join it, optionally waiting for completion."""
+def _kill_join(process: Optional[multiprocessing.Process], *, wait=False):
+    """Kill and join `process` if it was started, optionally waiting for completion."""
+    if process is None or process.pid is None:
+        return
     if process.exitcode is None:
         # POSIX multiprocessing backends tolerate the worker exiting between this poll and `kill()`.
         process.kill()
@@ -147,21 +147,3 @@ def _get_process_context(context):
         raise RuntimeError(
             f'processify requires platform support for the {context!r} multiprocessing start method',
         ) from None
-
-
-def _get_job_fn(process_context, fn, wrapper):
-    if process_context.get_start_method() == 'fork':
-        return fn, False
-    try:
-        pickle.dumps(fn)
-    except (pickle.PickleError, AttributeError, TypeError):
-        try:
-            pickle.dumps(wrapper)
-        except (pickle.PickleError, AttributeError, TypeError):
-            raise RuntimeError(
-                f'processify using {process_context.get_start_method()!r} requires `fn` or its wrapper '
-                'to be importable by module and qualified name',
-            ) from None
-        # The importable decorated name resolves to `wrapper`; the child bypasses this `processify` layer once.
-        return wrapper, True
-    return fn, False

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -2,7 +2,7 @@ import os
 import time
 import signal
 import functools
-from multiprocessing import Pipe, Process
+import multiprocessing
 from multiprocessing.connection import Connection as PipeConnection
 from threading import Thread
 from typing import Callable
@@ -15,17 +15,30 @@ def processify(fn):
     Note
     ----
     It doesn't encrypt communications with a child process.
+    It uses `fork` to support local and decorated functions, so call it only from a single-threaded process.
     """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        in_connection, out_connection = Pipe()
-        job_process = Process(target=_job, args=(os.getpid(), out_connection, fn, args, kwargs))
-        job_process.start()
-        Thread(target=_join_close, args=(job_process, out_connection), daemon=True).start()
+        in_connection, out_connection = _process_context.Pipe(duplex=False)
+        job_process = _process_context.Process(target=_job, args=(os.getpid(), out_connection, fn, args, kwargs))
         try:
-            result, exception = in_connection.recv()
-        except EOFError:  # happens when `_join_close()` closes `out_connection`
-            raise RuntimeError(f'Process running {fn} exited with code {job_process.exitcode}') from None
+            job_process.start()
+        except Exception:
+            in_connection.close()
+            out_connection.close()
+            raise
+        out_connection.close()
+        try:
+            try:
+                response = in_connection.recv()
+            except EOFError:
+                response = None
+        finally:
+            in_connection.close()
+            job_process.join()
+        if response is None:
+            raise RuntimeError(f'Process running {fn} exited with code {job_process.exitcode}')
+        result, exception = response
         if exception is not None:
             raise exception
         return result
@@ -40,12 +53,6 @@ def _suicide_when_orphan(ppid: int):
     os.kill(os.getpid(), signal.SIGKILL)  # suicide
 
 
-def _join_close(process: Process, connection: PipeConnection):
-    """Close pipe `connection` after `process` is done."""
-    process.join()
-    connection.close()
-
-
 def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, kwargs: dict):
     Thread(target=_suicide_when_orphan, args=(ppid,), daemon=True).start()
     try:
@@ -53,3 +60,9 @@ def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, k
     except Exception as e:
         result = (None, e)
     out_connection.send(result)
+
+
+try:
+    _process_context = multiprocessing.get_context('fork')
+except ValueError:
+    _process_context = multiprocessing.get_context()

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -1,5 +1,5 @@
 import os
-import time
+import pickle
 import signal
 import warnings
 import functools
@@ -9,21 +9,39 @@ from threading import Thread
 from typing import Callable
 
 
-def processify(fn):
+def processify(fn=None, *, context='fork'):
     """
     Decorate `fn` to run it in a separate process.
+
+    Parameters
+    ----------
+    fn : Callable
+        Function to decorate.
+    context : str, multiprocessing context, or None
+        Multiprocessing context or start method. Uses `fork` by default; `None` selects the application default.
 
     Note
     ----
     It doesn't encrypt communications with a child process.
-    It always uses `fork` to support local and decorated functions, independently of the application context.
-    `fn` must not use inherited mutable global state or synchronization primitives.
+    The default `fork` context supports local and decorated functions independently of the application context.
+    With `spawn` and `forkserver`, `fn` must be a module-level function or a regular or static method. When stacking
+    decorators, `processify` must be outermost and inner decorators must use `functools.wraps`. Arguments, results, and
+    exceptions must be pickleable.
+    Results must not depend on the worker remaining alive after they are deserialized.
+    Functions using `fork` must not use inherited mutable global state or synchronization primitives.
     In multithreaded processes, SIGINT protection during worker startup is best-effort because signal masks are
     thread-local.
     """
+    if fn is None:
+        return functools.partial(_processify, context=context)
+    return _processify(fn, context=context)
+
+
+def _processify(fn, *, context):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        process_context = _get_process_context()
+        process_context = _get_process_context(context)
+        job_fn, unwrap_fn = _get_job_fn(process_context, fn, wrapper)
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
@@ -34,7 +52,8 @@ def processify(fn):
                 job_process = process_context.Process(
                     target=_job,
                     args=(
-                        os.getpid(), in_connection, out_connection, fn, args, kwargs, previous_signal_mask,
+                        in_connection, out_connection, job_fn, unwrap_fn,
+                        args, kwargs, previous_signal_mask,
                     ),
                 )
                 # This scope is process-wide on regular CPython, so match only the expected `fork` warning.
@@ -80,17 +99,19 @@ def processify(fn):
     return wrapper
 
 
-def _suicide_when_orphan(ppid: int):
-    """Kill this process with SIGKILL signal if parent pid ≠ `ppid`."""
-    while os.getppid() == ppid:
-        time.sleep(1 / 4)
+def _suicide_when_orphan():
+    """Kill this process with SIGKILL signal when its logical parent exits."""
+    # Under `forkserver`, the OS parent is the fork server; multiprocessing tracks the caller through a sentinel.
+    parent_process = multiprocessing.parent_process()
+    assert parent_process is not None
+    parent_process.join()
     os.kill(os.getpid(), signal.SIGKILL)  # suicide
 
 
 def _kill_join(process: multiprocessing.Process, *, wait=False):
     """Kill `process` if it is running and join it, optionally waiting for completion."""
     if process.exitcode is None:
-        # The worker may exit after this check; fork Popen.kill() tolerates that race.
+        # POSIX multiprocessing backends tolerate the worker exiting between this poll and `kill()`.
         process.kill()
     if wait:
         process.join()
@@ -99,14 +120,17 @@ def _kill_join(process: multiprocessing.Process, *, wait=False):
 
 
 def _job(
-        ppid: int, in_connection: PipeConnection, out_connection: PipeConnection,
-        fn: Callable, args: tuple, kwargs: dict, signal_mask,
+        in_connection: PipeConnection, out_connection: PipeConnection, fn: Callable,
+        unwrap_fn: bool, args: tuple, kwargs: dict, signal_mask,
 ):
     # `fork` inherits both pipe ends, but the child only writes the response.
     in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
-    Thread(target=_suicide_when_orphan, args=(ppid,), daemon=True).start()
+    Thread(target=_suicide_when_orphan, daemon=True).start()
+    if unwrap_fn:
+        # `spawn` and `forkserver` can import the module-level wrapper; `__wrapped__` bypasses this decorator once.
+        fn = fn.__wrapped__
     try:
         result = (fn(*args, **kwargs), None)
     except Exception as e:
@@ -117,9 +141,30 @@ def _job(
         out_connection.close()
 
 
-def _get_process_context():
-    # Local and decorated functions cannot be serialized for `spawn` or `forkserver` by the standard pickler.
+def _get_process_context(context):
+    if not isinstance(context, str) and context is not None:
+        return context
     try:
-        return multiprocessing.get_context('fork')
+        return multiprocessing.get_context(context)
     except ValueError:
-        raise RuntimeError("processify requires platform support for the 'fork' multiprocessing start method") from None
+        raise RuntimeError(
+            f'processify requires platform support for the {context!r} multiprocessing start method',
+        ) from None
+
+
+def _get_job_fn(process_context, fn, wrapper):
+    if process_context.get_start_method() == 'fork':
+        return fn, False
+    try:
+        pickle.dumps(fn)
+    except (pickle.PickleError, AttributeError, TypeError):
+        try:
+            pickle.dumps(wrapper)
+        except (pickle.PickleError, AttributeError, TypeError):
+            raise RuntimeError(
+                f'processify using {process_context.get_start_method()!r} requires a module-level function '
+                'or a regular or static method; apply processify outermost and use functools.wraps in inner decorators',
+            ) from None
+        # The importable decorated name resolves to `wrapper`; the child bypasses this `processify` layer once.
+        return wrapper, True
+    return fn, False

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -23,8 +23,9 @@ def processify(fn=None, *, context='fork'):
     ----
     It doesn't encrypt communications with a child process.
     The default `fork` context supports local and decorated functions independently of the application context.
-    With `spawn` and `forkserver`, decorated functions must be importable by module and qualified name.
-    Arguments, results, and exceptions must be pickleable.
+    With `spawn` and `forkserver`, the decorated name must resolve to the `processify` wrapper by module and
+    qualified name, and arguments must be pickleable.
+    Results and exceptions must be pickleable in every context.
     Results must not depend on the worker remaining alive after they are deserialized.
     Functions using `fork` must not use inherited mutable global state or synchronization primitives.
     """

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -41,6 +41,8 @@ def processify(fn=None, *, context='fork'):
             # A signal delivered to another thread can still interrupt startup because POSIX masks are thread-local.
             previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             try:
+                # Spawn-like contexts pickle by module and qualified name, which resolve to `wrapper` after decoration.
+                # Passing it under `fork` too keeps one child path; `_job` removes only this decorator layer.
                 job_process = process_context.Process(
                     target=_job,
                     args=(

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -18,6 +18,8 @@ def processify(fn):
     It doesn't encrypt communications with a child process.
     It always uses `fork` to support local and decorated functions, independently of the application context.
     `fn` must not use inherited mutable global state or synchronization primitives.
+    In multithreaded processes, SIGINT protection during worker startup is best-effort because signal masks are
+    thread-local.
     """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -25,7 +27,8 @@ def processify(fn):
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
-            # Delay SIGINT until `start()` stores the child PID, so cleanup can always reach the worker.
+            # Block SIGINT in the calling thread to narrow the startup race until `start()` stores the child PID.
+            # A signal delivered to another thread can still interrupt startup because POSIX masks are thread-local.
             previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             try:
                 job_process = process_context.Process(
@@ -85,8 +88,10 @@ def _suicide_when_orphan(ppid: int):
 
 
 def _kill_join(process: multiprocessing.Process, *, wait=False):
-    """Kill `process` and join it, optionally waiting for completion."""
-    process.kill()
+    """Kill `process` if it is running and join it, optionally waiting for completion."""
+    if process.exitcode is None:
+        # The worker may exit after this check; fork Popen.kill() tolerates that race.
+        process.kill()
     if wait:
         process.join()
     else:

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -37,8 +37,10 @@ def processify(fn=None, *, context='fork'):
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
-            # Block SIGINT in the calling thread to narrow the startup race until `start()` stores the child PID.
-            # A signal delivered to another thread can still interrupt startup because POSIX masks are thread-local.
+            # SIGINT (for example, from Ctrl+C) can interrupt startup after the child is created but before
+            # `job_process` records its PID. Cleanup then sees a `None` PID and cannot terminate or join the child.
+            # Block SIGINT in this thread across that window.
+            # POSIX signal masks are thread-local, so another thread can still interrupt startup.
             previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             try:
                 # With decorator syntax, spawn-like contexts resolve `wrapper` by module and qualified name.

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import signal
 import warnings
 import functools
@@ -35,7 +34,6 @@ def processify(fn=None, *, context='fork'):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         process_context = _get_process_context(context)
-        job_fn, is_processify_wrapper = _select_job_callable(fn, wrapper, process_context)
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
@@ -43,13 +41,12 @@ def processify(fn=None, *, context='fork'):
             # A signal delivered to another thread can still interrupt startup because POSIX masks are thread-local.
             previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             try:
-                # `_job` only removes the `processify` layer when the selected callable is `wrapper`, so direct calls
-                # retain existing decorators.
+                # With decorator syntax, spawn-like contexts resolve `wrapper` by module and qualified name.
+                # Passing it under `fork` too keeps one child path; `_job` removes only the `processify` layer.
                 job_process = process_context.Process(
                     target=_job,
                     args=(
-                        in_connection, out_connection, job_fn, is_processify_wrapper,
-                        args, kwargs, previous_signal_mask,
+                        in_connection, out_connection, wrapper, args, kwargs, previous_signal_mask,
                     ),
                 )
                 # This scope is process-wide on regular CPython, so limit suppression to the `fork` backend.
@@ -113,17 +110,16 @@ def _kill_join(process: Optional[multiprocessing.Process], *, wait=False):
 
 
 def _job(
-        in_connection: PipeConnection, out_connection: PipeConnection, fn: Callable,
-        is_processify_wrapper: bool, args: tuple, kwargs: dict, signal_mask,
+        in_connection: PipeConnection, out_connection: PipeConnection, wrapper: Callable,
+        args: tuple, kwargs: dict, signal_mask,
 ):
     # `fork` inherits both pipe ends, but the child only writes the response.
     in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
     Thread(target=_suicide_when_orphan, daemon=True).start()
-    if is_processify_wrapper:
-        # `functools.wraps` stores the callable passed to `processify`, so only this decorator layer is bypassed.
-        fn = fn.__wrapped__
+    # `functools.wraps` stores the callable passed to `processify`, so only this decorator layer is bypassed.
+    fn = wrapper.__wrapped__
     try:
         result = (fn(*args, **kwargs), None)
     except Exception as e:
@@ -143,18 +139,3 @@ def _get_process_context(context):
         raise RuntimeError(
             f'processify requires platform support for the {context!r} multiprocessing start method',
         ) from None
-
-
-def _select_job_callable(fn, wrapper, context):
-    """Select the callable for `_job` and whether it should remove the `processify` layer."""
-    if context.get_start_method() == 'fork':
-        return wrapper, True
-    try:
-        value = sys.modules[wrapper.__module__]
-        for name in wrapper.__qualname__.split('.'):
-            value = getattr(value, name)
-    except (AttributeError, KeyError):
-        return fn, False
-    if value is wrapper:
-        return wrapper, True
-    return fn, False

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import signal
 import warnings
 import functools
@@ -23,8 +24,7 @@ def processify(fn=None, *, context='fork'):
     ----
     It doesn't encrypt communications with a child process.
     The default `fork` context supports local and decorated functions independently of the application context.
-    With `spawn` and `forkserver`, the decorated name must resolve to the `processify` wrapper by module and
-    qualified name, and arguments must be pickleable.
+    `spawn` and `forkserver` use their standard multiprocessing import and serialization rules.
     Results and exceptions must be pickleable in every context.
     Results must not depend on the worker remaining alive after they are deserialized.
     Functions using `fork` must not use inherited mutable global state or synchronization primitives.
@@ -35,6 +35,7 @@ def processify(fn=None, *, context='fork'):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         process_context = _get_process_context(context)
+        job_fn, is_processify_wrapper = _select_job_callable(fn, wrapper, process_context)
         in_connection, out_connection = process_context.Pipe(duplex=False)
         job_process = None
         try:
@@ -42,12 +43,13 @@ def processify(fn=None, *, context='fork'):
             # A signal delivered to another thread can still interrupt startup because POSIX masks are thread-local.
             previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
             try:
-                # Spawn-like contexts pickle by module and qualified name, which resolve to `wrapper` after decoration.
-                # Passing it under `fork` too keeps one child path; `_job` removes only this decorator layer.
+                # `_job` only removes the `processify` layer when the selected callable is `wrapper`, so direct calls
+                # retain existing decorators.
                 job_process = process_context.Process(
                     target=_job,
                     args=(
-                        in_connection, out_connection, wrapper, args, kwargs, previous_signal_mask,
+                        in_connection, out_connection, job_fn, is_processify_wrapper,
+                        args, kwargs, previous_signal_mask,
                     ),
                 )
                 # This scope is process-wide on regular CPython, so limit suppression to the `fork` backend.
@@ -111,16 +113,17 @@ def _kill_join(process: Optional[multiprocessing.Process], *, wait=False):
 
 
 def _job(
-        in_connection: PipeConnection, out_connection: PipeConnection, wrapper: Callable,
-        args: tuple, kwargs: dict, signal_mask,
+        in_connection: PipeConnection, out_connection: PipeConnection, fn: Callable,
+        is_processify_wrapper: bool, args: tuple, kwargs: dict, signal_mask,
 ):
     # `fork` inherits both pipe ends, but the child only writes the response.
     in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
     Thread(target=_suicide_when_orphan, daemon=True).start()
-    # `functools.wraps` stores the callable passed to `processify`, so only this decorator layer is bypassed.
-    fn = wrapper.__wrapped__
+    if is_processify_wrapper:
+        # `functools.wraps` stores the callable passed to `processify`, so only this decorator layer is bypassed.
+        fn = fn.__wrapped__
     try:
         result = (fn(*args, **kwargs), None)
     except Exception as e:
@@ -140,3 +143,18 @@ def _get_process_context(context):
         raise RuntimeError(
             f'processify requires platform support for the {context!r} multiprocessing start method',
         ) from None
+
+
+def _select_job_callable(fn, wrapper, context):
+    """Select the callable for `_job` and whether it should remove the `processify` layer."""
+    if context.get_start_method() == 'fork':
+        return wrapper, True
+    try:
+        value = sys.modules[wrapper.__module__]
+        for name in wrapper.__qualname__.split('.'):
+            value = getattr(value, name)
+    except (AttributeError, KeyError):
+        return fn, False
+    if value is wrapper:
+        return wrapper, True
+    return fn, False

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -113,7 +113,7 @@ def _job(
         in_connection: PipeConnection, out_connection: PipeConnection, wrapper: Callable,
         args: tuple, kwargs: dict, signal_mask,
 ):
-    # `fork` inherits both pipe ends, but the child only writes the response.
+    # # The worker only writes the response, so close its unused read end.
     in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -116,7 +116,7 @@ def _job(
         in_connection: PipeConnection, out_connection: PipeConnection, wrapper: Callable,
         args: tuple, kwargs: dict, signal_mask,
 ):
-    # # The worker only writes the response, so close its unused read end.
+    # The worker only writes the response, so close its unused read end.
     in_connection.close()
     # Undo the parent's startup-only SIGINT block before running user code.
     signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -31,6 +31,7 @@ def processify(fn):
                     target=_job,
                     args=(os.getpid(), out_connection, fn, args, kwargs, previous_signal_mask),
                 )
+                # This scope is process-wide on regular CPython, so match only the expected `fork` warning.
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         'ignore',

--- a/src/creepy/utils/processify.py
+++ b/src/creepy/utils/processify.py
@@ -16,38 +16,52 @@ def processify(fn):
     Note
     ----
     It doesn't encrypt communications with a child process.
-    It uses `fork` to support local and decorated functions, so `fn` must not use inherited global state.
+    It always uses `fork` to support local and decorated functions, independently of the application context.
+    `fn` must not use inherited mutable global state or synchronization primitives.
     """
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         in_connection, out_connection = _process_context.Pipe(duplex=False)
-        job_process = _process_context.Process(target=_job, args=(os.getpid(), out_connection, fn, args, kwargs))
+        job_process = None
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    'ignore',
-                    message=r'This process .* is multi-threaded, use of fork\(\) may lead to deadlocks in the child\.',
-                    category=DeprecationWarning,
-                    module=r'multiprocessing\.popen_fork',
+            # Delay SIGINT until `start()` stores the child PID, so cleanup can always reach the worker.
+            previous_signal_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
+            try:
+                job_process = _process_context.Process(
+                    target=_job,
+                    args=(os.getpid(), out_connection, fn, args, kwargs, previous_signal_mask),
                 )
-                job_process.start()
-            out_connection.close()
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        'ignore',
+                        message=(
+                            r'This process .* is multi-threaded, use of fork\(\) may lead '
+                            r'to deadlocks in the child\.'
+                        ),
+                        category=DeprecationWarning,
+                        module=r'multiprocessing\.popen_fork',
+                    )
+                    job_process.start()
+                out_connection.close()
+            finally:
+                signal.pthread_sigmask(signal.SIG_SETMASK, previous_signal_mask)
         except BaseException:
             in_connection.close()
             out_connection.close()
-            if job_process.pid is not None:
+            if job_process is not None and job_process.pid is not None:
                 _kill_join(job_process)
             raise
         try:
             response = in_connection.recv()
         except EOFError:
-            job_process.kill()
-            job_process.join()
+            # Wait only after killing the worker so its exit code is available without waiting for its threads.
+            _kill_join(job_process, wait=True)
             raise RuntimeError(f'Process running {fn} exited with code {job_process.exitcode}') from None
         except BaseException:
             _kill_join(job_process)
             raise
         else:
+            # `recv()` returned a fully deserialized response, so the disposable worker is no longer needed.
             _kill_join(job_process)
         finally:
             in_connection.close()
@@ -66,13 +80,18 @@ def _suicide_when_orphan(ppid: int):
     os.kill(os.getpid(), signal.SIGKILL)  # suicide
 
 
-def _kill_join(process: multiprocessing.Process):
-    """Kill `process` and join it in background."""
+def _kill_join(process: multiprocessing.Process, *, wait=False):
+    """Kill `process` and join it, optionally waiting for completion."""
     process.kill()
-    Thread(target=process.join, daemon=True).start()
+    if wait:
+        process.join()
+    else:
+        Thread(target=process.join, daemon=True).start()
 
 
-def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, kwargs: dict):
+def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, kwargs: dict, signal_mask):
+    # Undo the parent's startup-only SIGINT block before running user code.
+    signal.pthread_sigmask(signal.SIG_SETMASK, signal_mask)
     Thread(target=_suicide_when_orphan, args=(ppid,), daemon=True).start()
     try:
         result = (fn(*args, **kwargs), None)
@@ -84,4 +103,5 @@ def _job(ppid: int, out_connection: PipeConnection, fn: Callable, args: tuple, k
         out_connection.close()
 
 
+# Local and decorated functions cannot be serialized for `spawn` or `forkserver` by the standard pickler.
 _process_context = multiprocessing.get_context('fork')

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -124,7 +124,7 @@ def test_processify_with_context_object():
     assert processify(lambda: 42, context=multiprocessing.get_context('fork'))() == 42
     assert processify(_direct_worker, context=multiprocessing.get_context('spawn'))(21) == 42
     assert _application_context_worker() == multiprocessing.get_start_method()
-    with pytest.raises(RuntimeError, match='requires a module-level function'):
+    with pytest.raises(RuntimeError, match='importable by module and qualified name'):
         processify(lambda: None, context='spawn')()
 
 
@@ -144,8 +144,8 @@ def test_processify_child_crash():
             processify(quit)(i)
 
 
-# Turn the warning into an error to verify that `processify` suppresses its intentional `fork`.
 @pytest.mark.timeout(1)
+# Treat the intentional `processify` fork warning as an error unless the decorator suppresses it.
 @pytest.mark.filterwarnings('error:This process .* is multi-threaded:DeprecationWarning')
 def test_processify_parent_crash():
     connection = multiprocessing.Queue()

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -1,6 +1,7 @@
 import os
 import time
 import signal
+import functools
 import multiprocessing
 from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
@@ -11,9 +12,120 @@ import pytest
 from ..processify import processify
 
 
+def _double_result(fn):
+    @functools.wraps(fn)
+    def wrapper(value):
+        return fn(value) * 2
+
+    return wrapper
+
+
+@processify(context='spawn')
+@_double_result
+def _spawn_worker(value):
+    return value
+
+
+@processify(context='forkserver')
+@_double_result
+def _forkserver_worker(value):
+    return value
+
+
+@processify(context=None)
+def _application_context_worker():
+    return multiprocessing.get_start_method()
+
+
+def _direct_worker(value):
+    return value * 2
+
+
+class _Processified:
+    @processify(context='spawn')
+    def add(self, a, b):
+        return a + b
+
+    @staticmethod
+    @processify(context='spawn')
+    def multiply(a, b):
+        return a * b
+
+
+@processify(context='spawn')
+def _spawn_until_orphaned(connection):
+    connection.send(os.getpid())
+    time.sleep(100500)
+
+
+@processify(context='forkserver')
+def _forkserver_until_orphaned(connection):
+    connection.send(os.getpid())
+    time.sleep(100500)
+
+
+def _crash_processified_parent(worker, child_connection, crash_connection):
+    Thread(target=worker, args=(child_connection,), daemon=True).start()
+    crash_connection.recv()
+    os.kill(os.getpid(), signal.SIGKILL)
+
+
 def test_processify_on_simple_function():
     for i in range(100):
         assert i == processify(lambda: i)()
+
+
+def test_processify_as_decorator_factory():
+    @processify()
+    def add(a, b):
+        return a + b
+
+    assert add(1, 2) == 3
+
+
+def test_processify_with_non_fork_context():
+    methods = multiprocessing.get_all_start_methods()
+    for method, worker in (
+        ('spawn', _spawn_worker),
+        ('forkserver', _forkserver_worker),
+    ):
+        if method in methods:
+            assert worker(21) == 42
+    assert _Processified().add(1, 2) == 3
+    assert _Processified.multiply(2, 3) == 6
+
+
+@pytest.mark.timeout(10)
+def test_processify_orphan_with_non_fork_context():
+    methods = multiprocessing.get_all_start_methods()
+    for method, worker in (
+        ('spawn', _spawn_until_orphaned),
+        ('forkserver', _forkserver_until_orphaned),
+    ):
+        if method in methods:
+            child_in_connection, child_out_connection = multiprocessing.Pipe(duplex=False)
+            crash_in_connection, crash_out_connection = multiprocessing.Pipe(duplex=False)
+            parent = multiprocessing.get_context('spawn').Process(
+                target=_crash_processified_parent,
+                args=(worker, child_out_connection, crash_in_connection),
+            )
+            parent.start()
+            child_out_connection.close()
+            crash_in_connection.close()
+            child_pid = child_in_connection.recv()
+            crash_out_connection.send(None)
+            parent.join()
+            assert parent.exitcode == -signal.SIGKILL
+            time.sleep(0.5)
+            assert not psutil.pid_exists(child_pid)
+
+
+def test_processify_with_context_object():
+    assert processify(lambda: 42, context=multiprocessing.get_context('fork'))() == 42
+    assert processify(_direct_worker, context=multiprocessing.get_context('spawn'))(21) == 42
+    assert _application_context_worker() == multiprocessing.get_start_method()
+    with pytest.raises(RuntimeError, match='requires a module-level function'):
+        processify(lambda: None, context='spawn')()
 
 
 def test_processify_without_fork(monkeypatch):

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -20,6 +20,11 @@ def _double_result(fn):
     return wrapper
 
 
+@_double_result
+def _direct_worker(value):
+    return value
+
+
 @processify(context='spawn')
 @_double_result
 def _spawn_worker(value):
@@ -100,58 +105,70 @@ def test_processify_preserves_existing_decorator():
     assert processify(identity)(21) == 42
 
 
-def test_processify_with_non_fork_context():
-    methods = multiprocessing.get_all_start_methods()
-    for method, worker in (
+@pytest.mark.parametrize(
+    'method, worker',
+    (
         ('spawn', _spawn_worker),
         ('forkserver', _forkserver_worker),
-    ):
-        if method in methods:
-            assert worker(21) == 42
+    ),
+    ids=('spawn', 'forkserver'),
+)
+def test_processify_with_non_fork_context(method, worker):
+    if method not in multiprocessing.get_all_start_methods():
+        pytest.skip(f'{method} start method is unavailable')
+    assert worker(21) == 42
+    assert processify(_direct_worker, context=method)(21) == 42
+
+
+def test_processify_methods_with_spawn_context():
     assert _Processified().add(1, 2) == 3
     assert _Processified.multiply(2, 3) == 6
 
 
 @pytest.mark.timeout(10)
-def test_processify_orphan_with_non_fork_context():
-    methods = multiprocessing.get_all_start_methods()
-    for method, worker in (
+@pytest.mark.parametrize(
+    'method, worker',
+    (
         ('spawn', _spawn_until_orphaned),
         ('forkserver', _forkserver_until_orphaned),
-    ):
-        if method in methods:
-            child_in_connection, child_out_connection = multiprocessing.Pipe(duplex=False)
-            crash_in_connection, crash_out_connection = multiprocessing.Pipe(duplex=False)
-            parent = multiprocessing.get_context('spawn').Process(
-                target=_crash_processified_parent,
-                args=(worker, child_out_connection, crash_in_connection),
-            )
-            child_process = None
+    ),
+    ids=('spawn', 'forkserver'),
+)
+def test_processify_orphan_with_non_fork_context(method, worker):
+    if method not in multiprocessing.get_all_start_methods():
+        pytest.skip(f'{method} start method is unavailable')
+    child_in_connection, child_out_connection = multiprocessing.Pipe(duplex=False)
+    crash_in_connection, crash_out_connection = multiprocessing.Pipe(duplex=False)
+    parent = multiprocessing.get_context('spawn').Process(
+        target=_crash_processified_parent,
+        args=(worker, child_out_connection, crash_in_connection),
+    )
+    child_process = None
+    try:
+        parent.start()
+        child_out_connection.close()
+        crash_in_connection.close()
+        child_pid = child_in_connection.recv()
+        child_process = psutil.Process(child_pid)
+        crash_out_connection.send(None)
+        parent.join()
+        assert parent.exitcode == -signal.SIGKILL
+        _, alive = psutil.wait_procs([child_process], timeout=5)
+        assert not alive
+    finally:
+        child_in_connection.close()
+        child_out_connection.close()
+        crash_in_connection.close()
+        crash_out_connection.close()
+        if parent.pid is not None:
+            if parent.is_alive():
+                parent.kill()
+            parent.join()
+        if child_process is not None:
             try:
-                parent.start()
-                child_out_connection.close()
-                crash_in_connection.close()
-                child_pid = child_in_connection.recv()
-                child_process = psutil.Process(child_pid)
-                crash_out_connection.send(None)
-                parent.join()
-                assert parent.exitcode == -signal.SIGKILL
-                _, alive = psutil.wait_procs([child_process], timeout=5)
-                assert not alive
-            finally:
-                child_in_connection.close()
-                child_out_connection.close()
-                crash_in_connection.close()
-                crash_out_connection.close()
-                if parent.pid is not None:
-                    if parent.is_alive():
-                        parent.kill()
-                    parent.join()
-                if child_process is not None:
-                    try:
-                        child_process.kill()
-                    except psutil.NoSuchProcess:
-                        pass
+                child_process.kill()
+            except psutil.NoSuchProcess:
+                pass
 
 
 def test_processify_with_context_object():

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -43,13 +43,11 @@ def test_processify_preserves_existing_decorator():
 
 @pytest.mark.parametrize('method', ('spawn', 'forkserver'))
 def test_processify_with_non_fork_context(method):
-    if method not in multiprocessing.get_all_start_methods():
-        pytest.skip(f'{method} start method is unavailable')
-    worker = {
-        'spawn': _spawn_worker,
-        'forkserver': _forkserver_worker,
+    double_result = {
+        'spawn': _spawn_double_result,
+        'forkserver': _forkserver_double_result,
     }[method]
-    assert worker(21) == 42
+    assert double_result(21) == 42
 
 
 def test_processify_method_with_spawn_context():
@@ -59,9 +57,7 @@ def test_processify_method_with_spawn_context():
 @pytest.mark.timeout(10)
 @pytest.mark.parametrize('method', ('spawn', 'forkserver'))
 def test_processify_orphan_with_non_fork_context(method):
-    if method not in multiprocessing.get_all_start_methods():
-        pytest.skip(f'{method} start method is unavailable')
-    worker = {
+    until_orphaned = {
         'spawn': _spawn_until_orphaned,
         'forkserver': _forkserver_until_orphaned,
     }[method]
@@ -69,7 +65,7 @@ def test_processify_orphan_with_non_fork_context(method):
     crash_in_connection, crash_out_connection = multiprocessing.Pipe(duplex=False)
     parent = multiprocessing.get_context('spawn').Process(
         target=_crash_processified_parent,
-        args=(worker, child_out_connection, crash_in_connection),
+        args=(until_orphaned, child_out_connection, crash_in_connection),
     )
     child_process = None
     with child_in_connection, child_out_connection, crash_in_connection, crash_out_connection:
@@ -96,8 +92,8 @@ def test_processify_orphan_with_non_fork_context(method):
 
 
 def test_processify_with_context_selection():
-    assert _spawn_context_worker() == 42
-    assert _application_context_worker() == multiprocessing.get_start_method()
+    assert _spawn_with_context_object() == 42
+    assert _application_start_method() == multiprocessing.get_start_method()
 
 
 def test_processify_without_fork(monkeypatch):
@@ -209,23 +205,23 @@ def _double_result(fn):
 
 @processify(context='spawn')
 @_double_result
-def _spawn_worker(value):
+def _spawn_double_result(value):
     return value
 
 
 @processify(context='forkserver')
 @_double_result
-def _forkserver_worker(value):
+def _forkserver_double_result(value):
     return value
 
 
 @processify(context=multiprocessing.get_context('spawn'))
-def _spawn_context_worker():
+def _spawn_with_context_object():
     return 42
 
 
 @processify(context=None)
-def _application_context_worker():
+def _application_start_method():
     return multiprocessing.get_start_method()
 
 

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -20,11 +20,6 @@ def _double_result(fn):
     return wrapper
 
 
-@_double_result
-def _direct_worker(value):
-    return value
-
-
 @processify(context='spawn')
 @_double_result
 def _spawn_worker(value):
@@ -117,7 +112,6 @@ def test_processify_with_non_fork_context(method, worker):
     if method not in multiprocessing.get_all_start_methods():
         pytest.skip(f'{method} start method is unavailable')
     assert worker(21) == 42
-    assert processify(_direct_worker, context=method)(21) == 42
 
 
 def test_processify_methods_with_spawn_context():

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -32,6 +32,11 @@ def _forkserver_worker(value):
     return value
 
 
+@processify(context=multiprocessing.get_context('spawn'))
+def _spawn_context_worker():
+    return 42
+
+
 @processify(context=None)
 def _application_context_worker():
     return multiprocessing.get_start_method()
@@ -69,6 +74,14 @@ def _crash_processified_parent(worker, child_connection, crash_connection):
 def test_processify_on_simple_function():
     for i in range(100):
         assert i == processify(lambda: i)()
+
+
+def test_processify_fork_accepts_unpickleable_argument():
+    @processify
+    def call(fn):
+        return fn()
+
+    assert call(lambda: 42) == 42
 
 
 def test_processify_as_decorator_factory():
@@ -113,19 +126,37 @@ def test_processify_orphan_with_non_fork_context():
                 target=_crash_processified_parent,
                 args=(worker, child_out_connection, crash_in_connection),
             )
-            parent.start()
-            child_out_connection.close()
-            crash_in_connection.close()
-            child_pid = child_in_connection.recv()
-            crash_out_connection.send(None)
-            parent.join()
-            assert parent.exitcode == -signal.SIGKILL
-            time.sleep(0.5)
-            assert not psutil.pid_exists(child_pid)
+            child_process = None
+            try:
+                parent.start()
+                child_out_connection.close()
+                crash_in_connection.close()
+                child_pid = child_in_connection.recv()
+                child_process = psutil.Process(child_pid)
+                crash_out_connection.send(None)
+                parent.join()
+                assert parent.exitcode == -signal.SIGKILL
+                _, alive = psutil.wait_procs([child_process], timeout=5)
+                assert not alive
+            finally:
+                child_in_connection.close()
+                child_out_connection.close()
+                crash_in_connection.close()
+                crash_out_connection.close()
+                if parent.pid is not None:
+                    if parent.is_alive():
+                        parent.kill()
+                    parent.join()
+                if child_process is not None:
+                    try:
+                        child_process.kill()
+                    except psutil.NoSuchProcess:
+                        pass
 
 
 def test_processify_with_context_object():
     assert processify(lambda: 42, context=multiprocessing.get_context('fork'))() == 42
+    assert _spawn_context_worker() == 42
     assert _application_context_worker() == multiprocessing.get_start_method()
 
 

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -22,6 +22,7 @@ def test_processify_child_crash():
             processify(quit)(i)
 
 
+# Turn the warning into an error to verify that `processify` suppresses its intentional `fork`.
 @pytest.mark.timeout(1)
 @pytest.mark.filterwarnings('error:This process .* is multi-threaded:DeprecationWarning')
 def test_processify_parent_crash():
@@ -66,3 +67,42 @@ def test_processify_unpickleable_result_with_child_thread():
 
     with pytest.raises(RuntimeError, match=f'exited with code -{signal.SIGKILL}'):
         child()
+
+
+@pytest.mark.timeout(1)
+def test_processify_interrupt_during_start(monkeypatch):
+    child_pids = []
+    popen = multiprocessing.context.ForkProcess._Popen
+
+    def popen_and_interrupt(process):
+        child_process = popen(process)
+        child_pids.append(child_process.pid)
+        os.kill(os.getpid(), signal.SIGINT)
+        return child_process
+
+    monkeypatch.setattr(multiprocessing.context.ForkProcess, '_Popen', staticmethod(popen_and_interrupt))
+    with pytest.raises(KeyboardInterrupt):
+        processify(time.sleep)(100500)
+
+    time.sleep(0.1)
+    assert not psutil.pid_exists(child_pids[0])
+
+
+@pytest.mark.timeout(1)
+def test_processify_interrupt_during_receive():
+    connection = multiprocessing.Queue()
+    parent_pid = os.getpid()
+
+    @processify
+    def child():
+        connection.put(os.getpid())
+        time.sleep(0.1)
+        os.kill(parent_pid, signal.SIGINT)
+        time.sleep(100500)
+
+    with pytest.raises(KeyboardInterrupt):
+        child()
+
+    child_pid = connection.get(timeout=0.1)
+    time.sleep(0.1)
+    assert not psutil.pid_exists(child_pid)

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -47,11 +47,6 @@ class _Processified:
     def add(self, a, b):
         return a + b
 
-    @staticmethod
-    @processify(context='spawn')
-    def multiply(a, b):
-        return a * b
-
 
 @processify(context='spawn')
 def _spawn_until_orphaned(connection):
@@ -69,6 +64,21 @@ def _crash_processified_parent(worker, child_connection, crash_connection):
     Thread(target=worker, args=(child_connection,), daemon=True).start()
     crash_connection.recv()
     os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _assert_process_exits(pid, timeout=0.5):
+    try:
+        process = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return
+    _, alive = psutil.wait_procs([process], timeout=timeout)
+    # Do not leak the worker when the assertion fails.
+    for process in alive:
+        try:
+            process.kill()
+        except psutil.NoSuchProcess:
+            pass
+    assert not alive
 
 
 def test_processify_on_simple_function():
@@ -114,9 +124,8 @@ def test_processify_with_non_fork_context(method, worker):
     assert worker(21) == 42
 
 
-def test_processify_methods_with_spawn_context():
+def test_processify_method_with_spawn_context():
     assert _Processified().add(1, 2) == 3
-    assert _Processified.multiply(2, 3) == 6
 
 
 @pytest.mark.timeout(10)
@@ -138,35 +147,30 @@ def test_processify_orphan_with_non_fork_context(method, worker):
         args=(worker, child_out_connection, crash_in_connection),
     )
     child_process = None
-    try:
-        parent.start()
-        child_out_connection.close()
-        crash_in_connection.close()
-        child_pid = child_in_connection.recv()
-        child_process = psutil.Process(child_pid)
-        crash_out_connection.send(None)
-        parent.join()
-        assert parent.exitcode == -signal.SIGKILL
-        _, alive = psutil.wait_procs([child_process], timeout=5)
-        assert not alive
-    finally:
-        child_in_connection.close()
-        child_out_connection.close()
-        crash_in_connection.close()
-        crash_out_connection.close()
-        if parent.pid is not None:
-            if parent.is_alive():
-                parent.kill()
+    with child_in_connection, child_out_connection, crash_in_connection, crash_out_connection:
+        try:
+            parent.start()
+            child_out_connection.close()
+            crash_in_connection.close()
+            child_pid = child_in_connection.recv()
+            child_process = psutil.Process(child_pid)
+            crash_out_connection.send(None)
             parent.join()
-        if child_process is not None:
-            try:
-                child_process.kill()
-            except psutil.NoSuchProcess:
-                pass
+            assert parent.exitcode == -signal.SIGKILL
+            _assert_process_exits(child_pid, timeout=5)
+        finally:
+            if parent.pid is not None:
+                if parent.is_alive():
+                    parent.kill()
+                parent.join()
+            if child_process is not None:
+                try:
+                    child_process.kill()
+                except psutil.NoSuchProcess:
+                    pass
 
 
-def test_processify_with_context_object():
-    assert processify(lambda: 42, context=multiprocessing.get_context('fork'))() == 42
+def test_processify_with_context_selection():
     assert _spawn_context_worker() == 42
     assert _application_context_worker() == multiprocessing.get_start_method()
 
@@ -181,10 +185,10 @@ def test_processify_without_fork(monkeypatch):
         processify(lambda: None)()
 
 
-def test_processify_child_crash():
-    for i in range(2):
-        with pytest.raises(RuntimeError, match=f'exited with code {i}'):
-            processify(quit)(i)
+@pytest.mark.parametrize('exitcode', (0, 1))
+def test_processify_child_crash(exitcode):
+    with pytest.raises(RuntimeError, match=f'exited with code {exitcode}'):
+        processify(quit)(exitcode)
 
 
 @pytest.mark.timeout(1)
@@ -208,8 +212,7 @@ def test_processify_parent_crash():
         parent_future = executor.submit(parent)
         child_pid = connection.get()
         assert psutil.pid_exists(child_pid)
-        time.sleep(0.5)
-        assert not psutil.pid_exists(child_pid)
+        _assert_process_exits(child_pid)
         with pytest.raises(RuntimeError, match=f'exited with code -{signal.SIGKILL}'):
             parent_future.result()
 
@@ -249,8 +252,7 @@ def test_processify_interrupt_during_start(monkeypatch):
     with pytest.raises(KeyboardInterrupt):
         processify(time.sleep)(100500)
 
-    time.sleep(0.1)
-    assert not psutil.pid_exists(child_pids[0])
+    _assert_process_exits(child_pids[0])
 
 
 @pytest.mark.timeout(1)
@@ -269,5 +271,4 @@ def test_processify_interrupt_during_receive():
         child()
 
     child_pid = connection.get(timeout=0.1)
-    time.sleep(0.1)
-    assert not psutil.pid_exists(child_pid)
+    _assert_process_exits(child_pid)

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -45,7 +45,11 @@ def test_processify_preserves_existing_decorator():
 def test_processify_with_non_fork_context(method):
     if method not in multiprocessing.get_all_start_methods():
         pytest.skip(f'{method} start method is unavailable')
-    assert _WORKERS[method](21) == 42
+    worker = {
+        'spawn': _spawn_worker,
+        'forkserver': _forkserver_worker,
+    }[method]
+    assert worker(21) == 42
 
 
 def test_processify_method_with_spawn_context():
@@ -57,7 +61,10 @@ def test_processify_method_with_spawn_context():
 def test_processify_orphan_with_non_fork_context(method):
     if method not in multiprocessing.get_all_start_methods():
         pytest.skip(f'{method} start method is unavailable')
-    worker = _ORPHAN_WORKERS[method]
+    worker = {
+        'spawn': _spawn_until_orphaned,
+        'forkserver': _forkserver_until_orphaned,
+    }[method]
     child_in_connection, child_out_connection = multiprocessing.Pipe(duplex=False)
     crash_in_connection, crash_out_connection = multiprocessing.Pipe(duplex=False)
     parent = multiprocessing.get_context('spawn').Process(
@@ -238,17 +245,6 @@ def _spawn_until_orphaned(connection):
 def _forkserver_until_orphaned(connection):
     connection.send(os.getpid())
     time.sleep(100500)
-
-
-_WORKERS = {
-    'spawn': _spawn_worker,
-    'forkserver': _forkserver_worker,
-}
-
-_ORPHAN_WORKERS = {
-    'spawn': _spawn_until_orphaned,
-    'forkserver': _forkserver_until_orphaned,
-}
 
 
 def _crash_processified_parent(worker, child_connection, crash_connection):

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -37,10 +37,6 @@ def _application_context_worker():
     return multiprocessing.get_start_method()
 
 
-def _direct_worker(value):
-    return value * 2
-
-
 class _Processified:
     @processify(context='spawn')
     def add(self, a, b):
@@ -122,10 +118,7 @@ def test_processify_orphan_with_non_fork_context():
 
 def test_processify_with_context_object():
     assert processify(lambda: 42, context=multiprocessing.get_context('fork'))() == 42
-    assert processify(_direct_worker, context=multiprocessing.get_context('spawn'))(21) == 42
     assert _application_context_worker() == multiprocessing.get_start_method()
-    with pytest.raises(RuntimeError, match='importable by module and qualified name'):
-        processify(lambda: None, context='spawn')()
 
 
 def test_processify_without_fork(monkeypatch):

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -23,6 +23,7 @@ def test_processify_child_crash():
 
 
 @pytest.mark.timeout(1)
+@pytest.mark.filterwarnings('error:This process .* is multi-threaded:DeprecationWarning')
 def test_processify_parent_crash():
     connection = multiprocessing.Queue()
 
@@ -45,3 +46,23 @@ def test_processify_parent_crash():
         assert not psutil.pid_exists(child_pid)
         with pytest.raises(RuntimeError, match=f'exited with code -{signal.SIGKILL}'):
             parent_future.result()
+
+
+@pytest.mark.timeout(1)
+def test_processify_child_thread():
+    @processify
+    def child():
+        Thread(target=time.sleep, args=(100500,)).start()
+
+    child()
+
+
+@pytest.mark.timeout(1)
+def test_processify_unpickleable_result_with_child_thread():
+    @processify
+    def child():
+        Thread(target=time.sleep, args=(100500,)).start()
+        return lambda: None
+
+    with pytest.raises(RuntimeError, match=f'exited with code -{signal.SIGKILL}'):
+        child()

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -16,6 +16,16 @@ def test_processify_on_simple_function():
         assert i == processify(lambda: i)()
 
 
+def test_processify_without_fork(monkeypatch):
+    def get_context(method):
+        assert method == 'fork'
+        raise ValueError
+
+    monkeypatch.setattr(multiprocessing, 'get_context', get_context)
+    with pytest.raises(RuntimeError, match="requires platform support for the 'fork'"):
+        processify(lambda: None)()
+
+
 def test_processify_child_crash():
     for i in range(2):
         with pytest.raises(RuntimeError, match=f'exited with code {i}'):

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -79,6 +79,14 @@ def test_processify_as_decorator_factory():
     assert add(1, 2) == 3
 
 
+def test_processify_preserves_existing_decorator():
+    @_double_result
+    def identity(value):
+        return value
+
+    assert processify(identity)(21) == 42
+
+
 def test_processify_with_non_fork_context():
     methods = multiprocessing.get_all_start_methods()
     for method, worker in (
@@ -138,8 +146,8 @@ def test_processify_child_crash():
 
 
 @pytest.mark.timeout(1)
-# Treat the intentional `processify` fork warning as an error unless the decorator suppresses it.
-@pytest.mark.filterwarnings('error:This process .* is multi-threaded:DeprecationWarning')
+# Fail on any deprecation warning so changes to the intentional `fork` warning cannot bypass this test.
+@pytest.mark.filterwarnings('error::DeprecationWarning')
 def test_processify_parent_crash():
     connection = multiprocessing.Queue()
 

--- a/src/creepy/utils/tests/test_processify.py
+++ b/src/creepy/utils/tests/test_processify.py
@@ -12,75 +12,6 @@ import pytest
 from ..processify import processify
 
 
-def _double_result(fn):
-    @functools.wraps(fn)
-    def wrapper(value):
-        return fn(value) * 2
-
-    return wrapper
-
-
-@processify(context='spawn')
-@_double_result
-def _spawn_worker(value):
-    return value
-
-
-@processify(context='forkserver')
-@_double_result
-def _forkserver_worker(value):
-    return value
-
-
-@processify(context=multiprocessing.get_context('spawn'))
-def _spawn_context_worker():
-    return 42
-
-
-@processify(context=None)
-def _application_context_worker():
-    return multiprocessing.get_start_method()
-
-
-class _Processified:
-    @processify(context='spawn')
-    def add(self, a, b):
-        return a + b
-
-
-@processify(context='spawn')
-def _spawn_until_orphaned(connection):
-    connection.send(os.getpid())
-    time.sleep(100500)
-
-
-@processify(context='forkserver')
-def _forkserver_until_orphaned(connection):
-    connection.send(os.getpid())
-    time.sleep(100500)
-
-
-def _crash_processified_parent(worker, child_connection, crash_connection):
-    Thread(target=worker, args=(child_connection,), daemon=True).start()
-    crash_connection.recv()
-    os.kill(os.getpid(), signal.SIGKILL)
-
-
-def _assert_process_exits(pid, timeout=0.5):
-    try:
-        process = psutil.Process(pid)
-    except psutil.NoSuchProcess:
-        return
-    _, alive = psutil.wait_procs([process], timeout=timeout)
-    # Do not leak the worker when the assertion fails.
-    for process in alive:
-        try:
-            process.kill()
-        except psutil.NoSuchProcess:
-            pass
-    assert not alive
-
-
 def test_processify_on_simple_function():
     for i in range(100):
         assert i == processify(lambda: i)()
@@ -110,18 +41,11 @@ def test_processify_preserves_existing_decorator():
     assert processify(identity)(21) == 42
 
 
-@pytest.mark.parametrize(
-    'method, worker',
-    (
-        ('spawn', _spawn_worker),
-        ('forkserver', _forkserver_worker),
-    ),
-    ids=('spawn', 'forkserver'),
-)
-def test_processify_with_non_fork_context(method, worker):
+@pytest.mark.parametrize('method', ('spawn', 'forkserver'))
+def test_processify_with_non_fork_context(method):
     if method not in multiprocessing.get_all_start_methods():
         pytest.skip(f'{method} start method is unavailable')
-    assert worker(21) == 42
+    assert _WORKERS[method](21) == 42
 
 
 def test_processify_method_with_spawn_context():
@@ -129,17 +53,11 @@ def test_processify_method_with_spawn_context():
 
 
 @pytest.mark.timeout(10)
-@pytest.mark.parametrize(
-    'method, worker',
-    (
-        ('spawn', _spawn_until_orphaned),
-        ('forkserver', _forkserver_until_orphaned),
-    ),
-    ids=('spawn', 'forkserver'),
-)
-def test_processify_orphan_with_non_fork_context(method, worker):
+@pytest.mark.parametrize('method', ('spawn', 'forkserver'))
+def test_processify_orphan_with_non_fork_context(method):
     if method not in multiprocessing.get_all_start_methods():
         pytest.skip(f'{method} start method is unavailable')
+    worker = _ORPHAN_WORKERS[method]
     child_in_connection, child_out_connection = multiprocessing.Pipe(duplex=False)
     crash_in_connection, crash_out_connection = multiprocessing.Pipe(duplex=False)
     parent = multiprocessing.get_context('spawn').Process(
@@ -272,3 +190,83 @@ def test_processify_interrupt_during_receive():
 
     child_pid = connection.get(timeout=0.1)
     _assert_process_exits(child_pid)
+
+
+def _double_result(fn):
+    @functools.wraps(fn)
+    def wrapper(value):
+        return fn(value) * 2
+
+    return wrapper
+
+
+@processify(context='spawn')
+@_double_result
+def _spawn_worker(value):
+    return value
+
+
+@processify(context='forkserver')
+@_double_result
+def _forkserver_worker(value):
+    return value
+
+
+@processify(context=multiprocessing.get_context('spawn'))
+def _spawn_context_worker():
+    return 42
+
+
+@processify(context=None)
+def _application_context_worker():
+    return multiprocessing.get_start_method()
+
+
+class _Processified:
+    @processify(context='spawn')
+    def add(self, a, b):
+        return a + b
+
+
+@processify(context='spawn')
+def _spawn_until_orphaned(connection):
+    connection.send(os.getpid())
+    time.sleep(100500)
+
+
+@processify(context='forkserver')
+def _forkserver_until_orphaned(connection):
+    connection.send(os.getpid())
+    time.sleep(100500)
+
+
+_WORKERS = {
+    'spawn': _spawn_worker,
+    'forkserver': _forkserver_worker,
+}
+
+_ORPHAN_WORKERS = {
+    'spawn': _spawn_until_orphaned,
+    'forkserver': _forkserver_until_orphaned,
+}
+
+
+def _crash_processified_parent(worker, child_connection, crash_connection):
+    Thread(target=worker, args=(child_connection,), daemon=True).start()
+    crash_connection.recv()
+    os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _assert_process_exits(pid, timeout=0.5):
+    try:
+        process = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return
+    _, alive = psutil.wait_procs([process], timeout=timeout)
+    # Do not leak the worker when the assertion fails.
+    for process in alive:
+        try:
+            process.kill()
+        except psutil.NoSuchProcess:
+            pass
+    assert not alive


### PR DESCRIPTION
## Summary

- keep the existing `@processify` API on an explicit `fork` context by default, preserving closures, local functions, and current callers
- add backwards-compatible context selection through `@processify(context=...)`, accepting a start-method string, a multiprocessing context object, or `None` for the application's default context
- support explicit `spawn` and `forkserver` for workloads that cannot safely use `fork`, such as code that initializes CUDA/PyTorch state
- pass the `processify` wrapper through every context and bypass exactly that one layer in the child, preserving decorators already applied to the function
- use `multiprocessing.parent_process()` for orphan detection so cleanup follows the logical caller under `fork`, `spawn`, and `forkserver`
- make worker startup, pipe ownership, termination, and reaping deterministic on Python 3.14

## API and compatibility

Existing code continues to use `fork`:

```python
@processify
def worker(...):
    ...

@processify()
def another_worker(...):
    ...
```

Callers can opt into another start method or supply their own context:

```python
@processify(context='spawn')
def cuda_worker(...):
    ...

@processify(context=multiprocessing.get_context('forkserver'))
def server_worker(...):
    ...

@processify(context=None)  # use the application's default context
def application_default_worker(...):
    ...
```

Context lookup is deferred until invocation. `multiprocessing.get_context('fork')` returns the existing context singleton rather than creating a new context per call.

### Worker contract

- `fork` remains the default because it is the fastest path and is the only standard start method that supports the existing closure/local-function use cases without another serializer dependency. Fork arguments do not need to be pickleable.
- Forked workers must not use inherited mutable global state or inherited synchronization primitives.
- `spawn` and `forkserver` use their standard multiprocessing import and serialization rules. There is no public requirement involving the internal `processify` wrapper.
- Results and returned exceptions must be pickleable in every context because they cross a pipe. Results must be self-contained after deserialization and cannot depend on the worker remaining alive.

No new dependency such as `cloudpickle` or `dill` is introduced.

## Implementation details

`processify` contains its wrapper directly. Calling `processify(context=...)` returns `functools.partial(processify, context=...)`, so both decorator forms share one implementation without an extra decoration helper.

Every context passes that wrapper to `_job`. `fork` inherits it directly. With decorator syntax, `spawn` and `forkserver` import the wrapper through the normal module/qualified-name pickle mechanism. `_job` then follows `wrapper.__wrapped__` exactly once, removing only `processify` while retaining any decorator already applied to the function.

This also preserves direct use with the default fork context:

```python
@other_decorator
def foo(...):
    ...

processify(foo)(...)
```

Here `wrapper.__wrapped__` is still the callable returned by `other_decorator`, so it is executed rather than silently bypassed. There is no alternate selector, `sys.modules` lookup, or pickle preflight. If a programmatically created wrapper is not importable under a spawn-like context, multiprocessing reports its standard pickle error.

The previous orphan monitor compared `os.getppid()` with the caller PID. That is invalid for `forkserver`, where the worker's OS parent is the server. The reaper now waits on the public `multiprocessing.parent_process()` sentinel, which represents the logical caller. Parameterized regression tests kill a parent separately under `spawn` and `forkserver`, then wait for the worker to disappear with bounded cleanup rather than relying on a fixed sleep.

The worker lifecycle now also:

- uses a one-way pipe and closes both descriptors deterministically, including the worker's unused read end
- blocks SIGINT in the calling thread only across process startup, then restores the previous mask in the parent and worker; another thread may still receive SIGINT because POSIX signal masks are thread-local
- suppresses `DeprecationWarning` originating from `multiprocessing.popen_fork` only around `Process.start()`, without depending on unstable warning text
- kills the disposable worker after `recv()` fully deserializes a response and joins it asynchronously so worker-owned threads do not delay the caller
- treats child-side response serialization failure as EOF, then kills and synchronously joins the worker so its exit code is available
- re-raises parent-side receive/deserialization errors after scheduling worker cleanup asynchronously
- avoids signaling a worker whose exit code is already available; POSIX multiprocessing backends tolerate the remaining exit-between-poll-and-kill race

## Benchmarks

Environment: Linux, Python 3.14.3. Each process measurement includes context lookup, process startup, IPC, deserialization, worker termination, and scheduling the asynchronous join. Measurements use the exact runtime implementation published in this PR.

| Start method / operation | Samples | First call | Median | Mean | p95 |
| --- | ---: | ---: | ---: | ---: | ---: |
| `multiprocessing.get_context('fork')` lookup | 1,000,000 × 7 | — | **141.2 ns** per call (best repeat) | — | — |
| cached context variable access | 1,000,000 × 7 | — | **8.5 ns** per access (best repeat) | — | — |
| `processify` / `fork` | 100 | 5.003 ms | **2.260 ms** | 2.265 ms | 2.505 ms |
| `processify` / `spawn` | 30 | 597.069 ms | **598.382 ms** | 612.101 ms | 707.693 ms |
| `processify` / `forkserver` | 50 | 808.008 ms | **5.774 ms** | 6.373 ms | 9.496 ms |

Additional lifecycle measurements:

| Scenario | Samples | Result |
| --- | ---: | --- |
| Worker owning a 250 ms non-daemon thread | 100 | 2.252 ms median, 2.582 ms p95, 2.768 ms max; the thread did not delay the caller |
| 16 MiB result round trip | 10 | 49.034 ms median, 45.870–50.573 ms range |
| SIGINT scheduled 50 ms after entering `processify` | 1 | surfaced after 50.201 ms |
| Fork warnings escaping the scoped filter | 100 | 0 |

### Benchmark conclusions

- `fork` is the backwards-compatible default: its warmed median is ~2.26 ms versus ~598 ms for `spawn` in this import-heavy environment.
- Warm `forkserver` is relatively fast (~5.77 ms), but its first call pays the one-time server/import startup cost (~808 ms in this run).
- Context lookup remains negligible relative to process startup; caching the context would not materially improve the hot path.
- No explicit pickle preflight is performed, so spawn-like backends do not pay for duplicate serialization.
- A stress run of 500 fork calls, 10 spawn calls, and 200 forkserver calls left `(fds, threads, active children)` unchanged at `(6, 1, 0)`.
- Immediate worker termination is safe only for fully deserialized, self-contained results; the public contract intentionally excludes results backed by worker-owned lifetime-sensitive resources.

## Validation

Checks on the exact published tree (`743fd0485b1158adbd7645d4bb57400434ec0f49`):

- full Creepy suite on Python 3.14.3: `29 passed`; the one warning is from the separate pre-existing `creepy/utils/memory.py` direct `os.fork()` path
- focused processify suite with deprecations as errors: `18 passed` via `pytest -q src/creepy/utils/tests/test_processify.py -p no:cacheprovider -W error::DeprecationWarning`
- Tesoro secrets CLI integration with this Creepy checkout: `24 passed`
- the exact Tesoro #779 regression path no longer raises the original processify `PicklingError`; it reaches the expected private-key decryption step and stops in the non-interactive runner because no passphrase is available
- Python 3.11.9 standalone smoke/benchmark with the exact checkout successfully exercised `fork`, `spawn`, and `forkserver`
- parameterized cross-context coverage includes decorator-style calls under both `spawn` and `forkserver`, a spawn context object, the application-default context, an instance method and a non-pickleable fork argument
- the Linux/POSIX suite treats `spawn` and `forkserver` as required backends; unavailable methods fail instead of silently reducing coverage
- default-fork direct-call coverage proves that `processify(@other_decorator fn)` executes `other_decorator` rather than bypassing it
- orphan cleanup runs as distinct `spawn` and `forkserver` cases, uses bounded process waiting, and cleans up process/pipe handles on assertion failure
- redundant staticmethod and duplicate fork-context-object assertions were removed; repeated fixed sleeps now share bounded process-exit cleanup, while the remaining similar-looking tests cover distinct context or lifecycle branches; public tests precede a single private helpers/workers/classes block, matching Tesoro source organization, while one-use worker selection stays local to each test
- resource stress: 710 mixed-context calls with no fd, thread, or active-child growth
- Flake8 for the changed implementation, isort for both changed files, and `git diff --check`: passed
- two independent adversarial/style reviews searched for unnecessary public requirements, decorator bypass, residual selector complexity, duplicate serialization, context gaps, cleanup races, test isolation problems, style violations, and regressions across projects in `work`; the final review found no implementation issue, and its only wording finding was addressed by restricting the spawn-resolution comment explicitly to decorator syntax
- the PR is ready for review, mergeable, has no unresolved review threads, and changes only the two processify files relative to current `master`

GitHub currently reports no status checks or workflow runs for this repository/commit; the local validation above is the available test gate rather than a configured CI result.

Closes itesoro/tesoro#779